### PR TITLE
Current Transactions

### DIFF
--- a/bin/ximport.jl
+++ b/bin/ximport.jl
@@ -8,20 +8,23 @@ import LedgerTools.XImportModel
 
 function main()
     ledgerfile=nothing
-    newtransactions=Transaction[]
+    currenttransactions=Transaction[]
     currency="\$"
+    markcurrenttransactions=false
     
     while length(ARGS)>0
         x=popfirst!(ARGS)
         if x[1]=='-'
             if x=="-asb"
-                XImporters.asb(newtransactions,popfirst!(ARGS),currency)
+                XImporters.asb(currenttransactions,popfirst!(ARGS),currency)
             elseif x=="-ofx"
-                XImporters.ofx(newtransactions,popfirst!(ARGS),currency)
+                XImporters.ofx(currenttransactions,popfirst!(ARGS),currency)
             elseif x=="-nab"
-                XImporters.nab(newtransactions,popfirst!(ARGS),currency)
+                XImporters.nab(currenttransactions,popfirst!(ARGS),currency)
             elseif x=="-currency"
                 currency=popfirst!(ARGS)
+            elseif x=="-mark"
+                markcurrenttransactions=true
             else
                 error("Unknown option: ",x)
             end
@@ -34,11 +37,11 @@ function main()
         end
     end
 
-    sort!(newtransactions,by=t->t.date)
+    sort!(currenttransactions,by=t->t.date)
 
     ledgercontents,transactions=parseledgerfile(ledgerfile)
 
-    for t in newtransactions
+    for t in currenttransactions
         if !haskey(transactions,t.id)
             push!(ledgercontents,t)
             transactions[t.id]=t
@@ -53,7 +56,11 @@ function main()
         end
     end
 
-    writeledgerfile(ledgerfile,ledgercontents)
+    if markcurrenttransactions
+        writeledgerfile(ledgerfile,ledgercontents,[t.id for t in currenttransactions])
+    else
+        writeledgerfile(ledgerfile,ledgercontents,[])
+    end
 end
 
 main()

--- a/src/ximport.jl
+++ b/src/ximport.jl
@@ -13,7 +13,18 @@ end
 function parseledgerfile(fname)
     ledgercontents=[]
     transactions=Dict{String,Transaction}()
-    ls=map(rstrip,open(readlines,fname))
+
+    function cleanupline(x)
+        x=rstrip(x)
+        if length(x)>0
+            if x[1]=='*'
+                return x[2:end]
+            end
+        end
+        return x
+    end
+    
+    ls=map(cleanupline,open(readlines,fname))
 
     function noneleft()
         while length(ls)>0
@@ -32,6 +43,9 @@ function parseledgerfile(fname)
     end
     l=popfirst!(ls)
     if length(l)>0
+        if l[1]=='*'
+            l=l[2:end]
+        end
         if l[1]==';'
             l=l[2:end]
             @goto START

--- a/src/ximport.jl
+++ b/src/ximport.jl
@@ -100,9 +100,12 @@ function parseledgerfile(fname)
 end
 
 
-function writeledgerfile(fname,contents)
+function writeledgerfile(fname,contents,transactionidstomark)
     function tostring(t::Transaction)
         r="|$(t.id)|$(t.date)|$(t.amount)|$(t.matchinfo)\n"
+        if t.id in transactionidstomark
+            r="*"*r
+        end
         for x in t.text
             r=r*x*"\n"
         end


### PR DESCRIPTION
Allow the transactions that are present in the file to be imported to be marked with a leading * in the ledger file.

Marking such "current" transactions helps me as my bank doesn't do a good job of providing information that can be used to immutably identify each transaction --- the transaction id might take a few weeks to stabilise as it does this one ends up with duplicate transactions in the ledger file.  This feature makes those duplicates a lot easier to clean up.

Possibly breaking behaviour is that leading *s will now be removed from the ledger file at the parsing stage.  This means that * can no longer be used as a comment.